### PR TITLE
update: 写真一覧表示画面のブラッシュアップ

### DIFF
--- a/front/src/components/Photo.vue
+++ b/front/src/components/Photo.vue
@@ -1,9 +1,7 @@
 <template>
-  <div class="column is-4">
-    <figure>
-      <img :src="`${s3url}${src}`" />
-    </figure>
-  </div>
+  <figure class="figure_padding">
+    <img :src="`${s3url}${src}`" />
+  </figure>
 </template>
 
 <script>
@@ -16,3 +14,9 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.figure_padding {
+  padding-bottom: 8px;
+}
+</style>

--- a/front/src/views/Auth.vue
+++ b/front/src/views/Auth.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="content">
-    <div v-if="is_account_confirmation_success">{{success()}}</div>
+    <div v-if="is_account_confirmation_success">{{ success() }}</div>
     <b-tabs v-model="activeTab" position="is-centered" type="is-toggle">
       <b-tab-item label="ログイン">
         <LoginForm></LoginForm>

--- a/front/src/views/PhotoList.vue
+++ b/front/src/views/PhotoList.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="container">
-    <div class="columns is-multiline">
-      <Photo v-for="item in itemUrls" :key="item.id" :src="item.filename" />
+    <div class="is-3-columns-grid">
+      <div>
+        <Photo v-for="item in column_1_photoData" :key="item.id" :src="item.filename" />
+      </div>
+      <div>
+        <Photo v-for="item in column_2_photoData" :key="item.id" :src="item.filename" />
+      </div>
+      <div>
+        <Photo v-for="item in column_3_photoData" :key="item.id" :src="item.filename" />
+      </div>
     </div>
   </div>
 </template>
@@ -16,13 +24,35 @@ export default {
   },
   data() {
     return {
-      itemUrls: null
+      column_1_photoData: null,
+      column_2_photoData: null,
+      column_3_photoData: null
     };
   },
   methods: {
     async getPhotoLists() {
       const response = await axios.get("/photos");
-      this.itemUrls = response.data;
+      let i = 3;
+      let column_1_photoData = [];
+      let column_2_photoData = [];
+      let column_3_photoData = [];
+
+      for (let item of response.data) {
+        if (i % 3 === 0) {
+          column_1_photoData.push(item);
+        }
+        if (i % 3 === 1) {
+          column_2_photoData.push(item);
+        }
+        if (i % 3 === 2) {
+          column_3_photoData.push(item);
+        }
+        i++;
+      }
+
+      this.column_1_photoData = column_1_photoData;
+      this.column_2_photoData = column_2_photoData;
+      this.column_3_photoData = column_3_photoData;
     }
   },
   watch: {
@@ -35,3 +65,11 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.is-3-columns-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(338px, 1fr));
+  grid-column-gap: 15px;
+}
+</style>


### PR DESCRIPTION
## 概要
- issue: #9 

## ロジック
1. gridを3つ配置
1. gridの中に画像を表示する子コンポーネントを置く
1. APIで取得した画像URL情報を3分割する
1. 上記2. の子コンポーネントに3. で分割したデータをそれぞれ入れる


## 修正
- 画像の表示をbuefyのcolumnsで制御してたのを自作のgridに変更
- 写真一覧取得APIで受け取ったデータを3分割に変更