### PR TITLE
update: 写真投稿機能にアップロードファイルのサイズチェック追加

### DIFF
--- a/back/app/controllers/api/photos_controller.rb
+++ b/back/app/controllers/api/photos_controller.rb
@@ -5,6 +5,7 @@ class Api::PhotosController < ApplicationController
       key: "uploads/photo/#{SecureRandom.uuid}/${filename}",
       success_action_status: '201',
       acl: 'public-read',
+      content_length_range: 0..512000,
       expires: Time.now + 60)
       
       render json: {url: @presigned_object.url, fields: @presigned_object.fields}

--- a/front/src/components/PostPhotoForm.vue
+++ b/front/src/components/PostPhotoForm.vue
@@ -63,6 +63,7 @@ export default {
       preview: null,
       targetPhoto: null,
       isPhotoFormActive: this.isActive,
+      limitFileSize: 512000,
       sendPhotoDataToDB: {
         photo: {
           account_id: null,
@@ -76,12 +77,24 @@ export default {
       // 何も選択されていなかったら処理中断
       if (event.target.files.length === 0) {
         this.reset();
+        this.$store.dispatch("toast/error", "何も選択されませんでした！");
         return false;
       }
 
       // ファイルが画像ではなかったら処理中断
       if (!event.target.files[0].type.match("image.*")) {
         this.reset();
+        this.$store.dispatch("toast/error", "画像以外が選択されています！");
+        return false;
+      }
+
+      // ファイルサイズが500KB以上だったら処理中断
+      if (event.target.files[0].size >= this.limitFileSize) {
+        this.reset();
+        this.$store.dispatch(
+          "toast/error",
+          "ファイルサイズの上限は500KBです！"
+        );
         return false;
       }
 

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -3,12 +3,14 @@ import Vuex from "vuex";
 import createPersistedState from "vuex-persistedstate";
 
 import auth from "./auth.js";
+import toast from "./toast.js";
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
   modules: {
-    auth
+    auth,
+    toast
   },
   plugins: [
     createPersistedState({

--- a/front/src/store/toast.js
+++ b/front/src/store/toast.js
@@ -1,0 +1,40 @@
+import { ToastProgrammatic as Toast } from "buefy";
+
+const state = {
+  message: null
+};
+
+const getters = {};
+
+const mutations = {
+  setMessage(state, message) {
+    state.message = message;
+  }
+};
+
+const actions = {
+  async success(context, message) {
+    context.commit("setMessage", message);
+    Toast.open({
+      duration: 7000,
+      message: message,
+      type: "is-success"
+    });
+  },
+  async error(context, message) {
+    context.commit("setMessage", message);
+    Toast.open({
+      duration: 7000,
+      message: message,
+      type: "is-danger"
+    });
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+};


### PR DESCRIPTION
## 概要
- issue: #11 の対応

## 改修内容
- S3のpresigned_post のポリシーにファイルサイズ制限を追加
- Buefyのtoast機能をVuexで使えるように設定
- アップロードファイルのサイズが500KB以上のものが選択されたら処理を中断
- 処理中断時にエラーメッセージをVuexのtoastで表示させる