### PR TITLE
update: 認証機能に成功・失敗メッセージを追加

### DIFF
--- a/front/src/components/LoginForm.vue
+++ b/front/src/components/LoginForm.vue
@@ -25,7 +25,7 @@ export default {
     return {
       LoginData: {
         email: "hoge@email.com",
-        password: "hogehoge"
+        password: "password"
       }
     };
   },

--- a/front/src/components/RegisterForm.vue
+++ b/front/src/components/RegisterForm.vue
@@ -27,6 +27,8 @@
 </template>
 
 <script>
+import httpResponse from "../constant.js";
+
 export default {
   data() {
     return {
@@ -39,8 +41,14 @@ export default {
   },
   methods: {
     async accountRegister() {
-      await this.$store.dispatch("auth/accountRegister", this.RegisterData);
-      this.$router.push("/");
+      await this.$store
+        .dispatch("auth/accountRegister", this.RegisterData)
+        .catch(e => console.log(e));
+
+      // ユーザ登録API成功なら画面遷移
+      if (this.$store.state.auth.httpresponse === httpResponse.SUCCSESS) {
+        this.$router.push("/auth/confirm", () => {});
+      }
     }
   }
 };

--- a/front/src/constant.js
+++ b/front/src/constant.js
@@ -1,0 +1,5 @@
+export default Object.freeze({
+  SUCCSESS: 200,
+  UN_AUTHORIZED: 401,
+  CREATED: 201
+});

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -3,6 +3,7 @@ import VueRouter from "vue-router";
 import PhotoList from "../views/PhotoList.vue";
 import TestPhotoList from "../views/TestPhotoList.vue";
 import Auth from "../views/Auth.vue";
+import confirm from "../views/auth/confirm.vue";
 
 Vue.use(VueRouter);
 
@@ -16,6 +17,11 @@ const routes = [
     path: "/auth",
     name: "Auth",
     component: Auth
+  },
+  {
+    path: "/auth/confirm",
+    name: "confirm",
+    component: confirm
   },
   {
     path: "/test",

--- a/front/src/store/toast.js
+++ b/front/src/store/toast.js
@@ -16,7 +16,7 @@ const actions = {
   async success(context, message) {
     context.commit("setMessage", message);
     Toast.open({
-      duration: 7000,
+      duration: 5000,
       message: message,
       type: "is-success"
     });
@@ -24,7 +24,7 @@ const actions = {
   async error(context, message) {
     context.commit("setMessage", message);
     Toast.open({
-      duration: 7000,
+      duration: 5000,
       message: message,
       type: "is-danger"
     });

--- a/front/src/views/auth/confirm.vue
+++ b/front/src/views/auth/confirm.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="container is-fluid">
+    <div class="columns is-centered is-marginless">
+      <div class="column is-three-quarters">
+        <div class="content is-large">ユーザ登録確認の為にメールを送信しました。メール本文の「アカウントを有効化する」をクリックしてユーザ登録を完了させて下さい。</div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
- ログイン後に「ログインしました」等、認証周りの処理にtoastメッセージを追加
- ユーザ登録API成功時にアカウント有効化メールの確認を促すページへ遷移する処理追加